### PR TITLE
ELSAF-2: Configure Heroku support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "author": "Ross MacPhee (https://github.com/rossyman)",
   "license": "MIT",
   "scripts": {
-    "start": "ng serve",
-    "start:prod": "ng serve --prod",
+    "start": "node server.js",
+    "serve": "ng serve",
+    "serve:prod": "ng serve --prod",
     "build": "ng build",
     "build:prod": "ng build --prod",
     "test": "ng test",
@@ -18,25 +19,28 @@
     "test:headless": "ng test -c=headless",
     "test:headless:watch": "ng test -c=headless --watch",
     "lint": "ng lint",
-    "postinstall": "ngcc"
+    "postinstall": "ngcc",
+    "heroku-postbuild": "npm run build:prod"
   },
   "dependencies": {
+    "@angular-devkit/build-angular": "~0.1001.4",
     "@angular/animations": "~10.1.4",
+    "@angular/cli": "~10.1.4",
     "@angular/common": "~10.1.4",
     "@angular/compiler": "~10.1.4",
+    "@angular/compiler-cli": "~10.1.4",
     "@angular/core": "~10.1.4",
     "@angular/forms": "~10.1.4",
     "@angular/platform-browser": "~10.1.4",
     "@angular/platform-browser-dynamic": "~10.1.4",
     "@angular/router": "~10.1.4",
+    "express": "^4.17.1",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
+    "typescript": "~4.0.2",
     "zone.js": "~0.10.2"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.1001.4",
-    "@angular/cli": "~10.1.4",
-    "@angular/compiler-cli": "~10.1.4",
     "@types/node": "^12.11.1",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
@@ -50,7 +54,10 @@
     "karma-jasmine-html-reporter": "^1.5.0",
     "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
-    "tslint": "~6.1.0",
-    "typescript": "~4.0.2"
+    "tslint": "~6.1.0"
+  },
+  "engines": {
+    "node": "12.18.3",
+    "npm": "6.14.8"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+
+app.use(express.static(__dirname + '/dist/electricsafari'));
+app.get('/*', (req, res) => res.sendFile(path.join(__dirname + '/dist/electricsafari/index.html')));
+app.listen(process.env.PORT || 8080);


### PR DESCRIPTION
Configure Heroku support for the ES2 application.

### Acceptance Criteria
- [x] Add express support
- [x] Add Heroku NPM hooks

### Linked Issues
Closes #3 