### PR TITLE
ELSAF-4: Setup Dependabot for GitHub Actions & NPM dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "rossyman"
+    reviewers:
+      - "rossyman"
+    commit-message:
+      prefix: "ELSAF-D"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "rossyman"
+    reviewers:
+      - "rossyman"
+    commit-message:
+      prefix: "ELSAF-D"
+      include: "scope"


### PR DESCRIPTION
Setup Dependabot for GitHub Actions & NPM dependencies to ensure that we use all non-breaking bugfix and patch versions available to us.

### Acceptance Criteria
- [x] Enable Dependabot for NPM
- [x] Enable Dependabot for GitHub Actions

### Linked Issues
Closes #8 