### PR TITLE
ELSAF-9: Add SEO description

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,7 @@
   <meta name="msapplication-config" content="assets/browserconfig.xml">
   <meta name="msapplication-TileColor" content="#603cba">
   <meta name="theme-color" content="#070707">
+  <meta name="description" content="Electric Safari is a digital festival and adventure through musical soundscapes ✨">
 
   <title>Electric Safari II</title>
 


### PR DESCRIPTION
Add a description `<meta>` tag to the site, in order to provide better SEO and indexed results.

### Acceptance Criteria
- [x] A description `<meta>` tag on the site

### Linked Issues
Closes #34 